### PR TITLE
added virtual destruct for ObjectSpace.h

### DIFF
--- a/lib/NGT/ObjectSpace.h
+++ b/lib/NGT/ObjectSpace.h
@@ -186,6 +186,7 @@ namespace NGT {
 #ifdef NGT_SHARED_MEMORY_ALLOCATOR
       SharedMemoryAllocator &allocator;
 #endif
+      virtual ~Comparator(){}
     };
     enum DistanceType {
       DistanceTypeNone		= -1,
@@ -196,7 +197,7 @@ namespace NGT {
     };
     typedef priority_queue<ObjectDistance, vector<ObjectDistance>, less<ObjectDistance> > ResultSet;
     ObjectSpace(size_t d):dimension(d), distanceType(DistanceTypeNone), comparator(0) {}
-    ~ObjectSpace() { if (comparator != 0) { delete comparator; } }
+    virtual ~ObjectSpace() { if (comparator != 0) { delete comparator; } }
     
 #ifdef NGT_SHARED_MEMORY_ALLOCATOR
     virtual void open(const string &f, size_t shareMemorySize) = 0;


### PR DESCRIPTION
I recieved "non-virtual destruct" warnings from compiler when compiled this code.
I added virtual specifier to Comparator  class and ObjectSpace class.