### PR TITLE
fix python usage

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -24,7 +24,7 @@ pip install dist/ngt-1.0.0.tar.gz
       objects.append(vector)
 
   query = objects[0]
-  index = ngt.Index.create("tmp", dim)
+  index = ngt.Index.create(b"tmp", dim)
   index.insert(objects)
   # You can also insert objects from a file like this.
   # index.insert_from_tsv('list.tsv') 


### PR DESCRIPTION
pythonのusageをそのまま実行すると
```ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type```
が出るため、修正しました。