### PR TITLE
enable cosine distance for python binding

### DIFF
--- a/lib/NGT/Capi.cpp
+++ b/lib/NGT/Capi.cpp
@@ -242,6 +242,18 @@ bool ngt_set_property_distance_type_hamming(NGTProperty prop, NGTError error) {
   return true;
 }
 
+bool ngt_set_property_distance_type_cosine(NGTProperty prop, NGTError error) {
+  if(prop == NULL){
+    std::stringstream ss;
+    ss << "Capi : " << __FUNCTION__ << "() : parametor error: prop = " << prop;
+    operate_error_string_(ss, error);
+    return false;
+  }
+ 
+  (*static_cast<NGT::Property*>(prop)).distanceType = NGT::Index::Property::DistanceType::DistanceTypeCosine;
+  return true;
+}
+
 NGTObjectDistances ngt_create_empty_results(NGTError error) {
   try{
     return static_cast<NGTObjectDistances>(new NGT::ObjectDistances());

--- a/lib/NGT/Capi.h
+++ b/lib/NGT/Capi.h
@@ -72,6 +72,8 @@ bool ngt_set_property_distance_type_angle(NGTProperty, NGTError);
 
 bool ngt_set_property_distance_type_hamming(NGTProperty, NGTError);
 
+bool ngt_set_property_distance_type_cosine(NGTProperty, NGTError);
+
 NGTObjectDistances ngt_create_empty_results(NGTError);
 
 bool ngt_search_index(NGTIndex, double*, int32_t, size_t, float, NGTObjectDistances, NGTError);

--- a/python/ngt/base.py
+++ b/python/ngt/base.py
@@ -127,6 +127,8 @@ class Index(object):
     __ngt.ngt_set_property_distance_type_hamming.argtypes = [
                                                         c_void_p, c_void_p]
 
+    __ngt.ngt_set_property_distance_type_cosine.argtypes = [c_void_p, c_void_p]
+
     __ngt.ngt_create_empty_results.argtype = [c_void_p]
     __ngt.ngt_create_empty_results.restype = c_void_p
 
@@ -200,7 +202,7 @@ class Index(object):
           edge_size_for_creation : Number of edges for each node in the graph.
           edge_size_for_search   : Number of edges to search.
           object_type            : Type of the data object. (Float, Integer [Integer is 1 byte])
-          distance_type          : Type of the distance function. (L1,L2,Angle,Hamming)
+          distance_type          : Type of the distance function. (L1,L2,Angle,Hamming,Cosine)
         '''
         err = None
         prop = None
@@ -244,6 +246,10 @@ class Index(object):
                 Index._check_error_num(stat, err)
             elif distance_type == "Hamming":
                 stat = Index.__ngt.ngt_set_property_distance_type_hamming(
+                                                                prop, err)
+                Index._check_error_num(stat, err)
+            elif distance_type == "Cosine":
+                stat = Index.__ngt.ngt_set_property_distance_type_cosine(
                                                                 prop, err)
                 Index._check_error_num(stat, err)
 


### PR DESCRIPTION
Pythonでもコサイン距離での近傍検索を行えるようにしたいです。

```python
index = ngt.Index.create(b'index_name', dim, distance_type='Cosine')
```