### PR TITLE
Added Homebrew and fix GCC build instructions for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Installation
 
 - [Releases](https://github.com/yahoojapan/NGT/releases)
 
+### Pre-Built
+
+#### On macOS
+
+      $ brew install ngt
+
 ### Build
 
 #### On Linux
@@ -47,9 +53,9 @@ Installation
       $ unzip NGT-x.x.x.zip
       $ cd NGT-x.x.x
       $ mkdir build
-      $ cd build 
+      $ cd build
       $ cmake ..
-      $ make 
+      $ make
       $ make install
       $ ldconfig /usr/local/lib
 
@@ -58,14 +64,14 @@ Installation
       $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
       $ brew install cmake
       $ brew install gcc@9
-      $ export CXX=/usr/local/bin/g++
-      $ export CC=/usr/local/bin/gcc
+      $ export CXX=/usr/local/bin/g++-9
+      $ export CC=/usr/local/bin/gcc-9
       $ unzip NGT-x.x.x.zip
       $ cd NGT-x.x.x
       $ mkdir build
-      $ cd build 
+      $ cd build
       $ cmake ..
-      $ make 
+      $ make
       $ make install
 
 #### Shared memory use


### PR DESCRIPTION
This PR:

1. Fixes GCC instructions on Mac (`gcc` -> `gcc-9` and `g++` -> `g++-9`) - #57 
2. Adds Homebrew instructions

I wasn't sure the best place for the Homebrew instructions (or how to label it), so let me know if you'd like it somewhere else.