### PR TITLE
Expose import and export functions in Python API

### DIFF
--- a/python/README-ngtpy.md
+++ b/python/README-ngtpy.md
@@ -139,6 +139,28 @@ Specify the search radius. The default is infinity.
 **Returns**   
 None.
 
+### export_index
+Exports the index to a file.
+
+      export_index(self: ngtpy.Index, path: str)
+
+**path**    
+Path to file in which the exported index will be stored.
+
+**Returns**   
+None.
+
+### import_index
+Imports the index from a file
+
+      import_index(self: ngtpy.Index, path: str)
+
+**path**    
+Path to file from which to load the index.
+
+**Returns**   
+None.
+
 
 FUNCTIONS
 =========

--- a/python/src/ngtpy.cpp
+++ b/python/src/ngtpy.cpp
@@ -328,6 +328,14 @@ public:
     }
   }
 
+  void exportIndex(const std::string path) {
+    NGT::Index::exportIndex(path);
+  }
+
+  void importIndex(const std::string path) {
+    NGT::Index::importIndex(path);
+  }
+
   size_t getNumOfDistanceComputations() { return numOfDistanceComputations; }
 
   bool		zeroNumbering;	    // for object ID numbering. zero-based or one-based numbering.
@@ -426,7 +434,11 @@ PYBIND11_MODULE(ngtpy, m) {
 	   py::arg("batch_size") = 10000)
       .def("set", &::Index::set,
            py::arg("num_of_search_objects") = 0,
-	   py::arg("search_radius") = -1.0);
+	   py::arg("search_radius") = -1.0)
+      .def("export_index", &::Index::exportIndex, 
+           py::arg("path"))
+      .def("import_index", &::Index::importIndex, 
+           py::arg("path"));
 
 
     py::class_<Optimizer>(m, "Optimizer")


### PR DESCRIPTION
This pull request adds functionality to export and import indices from the python API and solves https://github.com/yahoojapan/NGT/issues/76

I have updated the English documentation as well.

Request you to update Japanese documentation and merge this in and release new Python wheels so that I don't have to maintain this branch.

Thanks,
Orkhan