### PR TITLE
Clean-up unused imports from setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -25,12 +25,6 @@ if included_library_option in sys.argv:
 
 if sys.version_info.major >= 3:
     from setuptools import Extension
-    try:
-        # for pip < 10.0
-        from pip import locations
-    except ImportError:
-        # for pip >= 10.0
-        from pip._internal import locations
 
 if os.path.isfile('../' + version_file):
     shutil.copyfile('../' + version_file, version_file)


### PR DESCRIPTION
I clean-up unused imports. The function `locations` is not used any more since https://github.com/yahoojapan/NGT/commit/85c4e01ee4f0c791f3ed633be49de677e5228d10.