### PR TITLE
[BUGFIX] Unsupported instruction was included in the Hamming distance AVX512 processing.

### DIFF
--- a/lib/NGT/PrimitiveComparator.h
+++ b/lib/NGT/PrimitiveComparator.h
@@ -443,73 +443,95 @@ namespace NGT {
 
 #if defined(NGT_NO_AVX) || !defined(__POPCNT__)
     inline static double popCount(uint32_t x) {
-      x = (x & 0x55555555) + (x >> 1 & 0x55555555);
-      x = (x & 0x33333333) + (x >> 2 & 0x33333333);
-      x = (x & 0x0F0F0F0F) + (x >> 4 & 0x0F0F0F0F);
-      x = (x & 0x00FF00FF) + (x >> 8 & 0x00FF00FF);
-      x = (x & 0x0000FFFF) + (x >> 16 & 0x0000FFFF);
-      return x;
+          x = (x & 0x55555555) + (x >> 1 & 0x55555555);
+          x = (x & 0x33333333) + (x >> 2 & 0x33333333);
+          x = (x & 0x0F0F0F0F) + (x >> 4 & 0x0F0F0F0F);
+          x = (x & 0x00FF00FF) + (x >> 8 & 0x00FF00FF);
+          x = (x & 0x0000FFFF) + (x >> 16 & 0x0000FFFF);
+          return x;
     }
 
     template <typename OBJECT_TYPE>
     inline static double compareHammingDistance(const OBJECT_TYPE *a, const OBJECT_TYPE *b, size_t size) {
-      const uint32_t *last = reinterpret_cast<const uint32_t*>(a + size);
-      const uint32_t *uinta = reinterpret_cast<const uint32_t*>(a);
-      const uint32_t *uintb = reinterpret_cast<const uint32_t*>(b);
-      size_t count = 0;
-      while( uinta < last ){
-	count += popCount(*uinta++ ^ *uintb++);
-      }
+          const uint32_t *last = reinterpret_cast<const uint32_t *>(a + size);
+          const uint32_t *uinta = reinterpret_cast<const uint32_t *>(a);
+          const uint32_t *uintb = reinterpret_cast<const uint32_t *>(b);
+          size_t count = 0;
+          while (uinta < last) {
+                count += popCount(*uinta++ ^ *uintb++);
+          }
 
-      return static_cast<double>(count);
+          return static_cast<double>(count);
     }
 #else
-template <typename OBJECT_TYPE>
-inline static double compareHammingDistance(const OBJECT_TYPE *a, const OBJECT_TYPE *b, size_t size)
-{
-    size_t count = 0;
-    const OBJECT_TYPE *last = a + size;
-#if defined(__AVX512F__)
-    while (a + 64 <= last)
+    template <typename OBJECT_TYPE>
+    inline static double compareHammingDistance(const OBJECT_TYPE *a, const OBJECT_TYPE *b, size_t size)
     {
-        __m512i vxor = _mm512_xor_si512(_mm512_loadu_si512(reinterpret_cast<const __m512i *>(a)), _mm512_loadu_si512(reinterpret_cast<const __m512i *>(b)));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 0));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 1));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 2));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 3));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 4));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 5));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 6));
-        count += _mm_popcnt_u64(_mm512_extract_epi64(vxor, 7));
-        a += 64;
-        b += 64;
-    }
+          size_t count = 0;
+          const OBJECT_TYPE *last = a + size;
+#if defined(__AVX512F__)
+          while (a + 64 <= last)
+          {
+                __m512i vxor = _mm512_xor_si512(_mm512_loadu_si512(reinterpret_cast<const __m512i *>(a)), _mm512_loadu_si512(reinterpret_cast<const __m512i *>(b)));
+
+#if defined(__AVX512VPOPCNTDQ__)
+                count += _mm512_reduce_add_epi64(_mm512_popcnt_epi64(vxor));
+#else
+                __m256i lower = _mm512_castsi512_si256(vxor);
+                count += _mm_popcnt_u64(_mm256_extract_epi64(lower, 0));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(lower, 1));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(lower, 2));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(lower, 3));
+
+                __m256i upper = _mm512_extracti64x4_epi64(vxor, 1);
+                count += _mm_popcnt_u64(_mm256_extract_epi64(upper, 0));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(upper, 1));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(upper, 2));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(upper, 3));
+#endif
+
+                a += 64;
+                b += 64;
+          }
 #endif
 
 #if defined(__AVX512F__) || defined(__AVX2__)
-    while (a + 32 <= last)
-    {
-        __m256i vxor = _mm256_xor_si256(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(a)), _mm256_loadu_si256(reinterpret_cast<const __m256i *>(b)));
-        count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 0));
-        count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 1));
-        count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 2));
-        count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 3));
-        a += 32;
-        b += 32;
-    }
+          while (a + 32 <= last)
+          {
+                __m256i vxor = _mm256_xor_si256(_mm256_loadu_si256(reinterpret_cast<const __m256i *>(a)), _mm256_loadu_si256(reinterpret_cast<const __m256i *>(b)));
+
+#if defined(__AVX512VPOPCNTDQ__) && defined(__AVX512VL__)
+                __m256i popcnt = _mm256_popcnt_epi64(vxor);
+                count += _mm256_extract_epi64(popcnt, 0);
+                count += _mm256_extract_epi64(popcnt, 1);
+                count += _mm256_extract_epi64(popcnt, 2);
+                count += _mm256_extract_epi64(popcnt, 3);
+#else
+                count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 0));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 1));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 2));
+                count += _mm_popcnt_u64(_mm256_extract_epi64(vxor, 3));
 #endif
-    while (a < last)
-    {
-        __m128i vxor = _mm_xor_si128(_mm_loadu_si128(reinterpret_cast<const __m128i *>(a)), _mm_loadu_si128(reinterpret_cast<const __m128i *>(b)));
-        count += _mm_popcnt_u32(_mm_extract_epi32(vxor, 0));
-        count += _mm_popcnt_u32(_mm_extract_epi32(vxor, 1));
-        count += _mm_popcnt_u32(_mm_extract_epi32(vxor, 2));
-        count += _mm_popcnt_u32(_mm_extract_epi32(vxor, 3));
-        a += 16;
-        b += 16;
+                a += 32;
+                b += 32;
+          }
+#endif
+          while (a < last)
+          {
+                __m128i vxor = _mm_xor_si128(_mm_loadu_si128(reinterpret_cast<const __m128i *>(a)), _mm_loadu_si128(reinterpret_cast<const __m128i *>(b)));
+#if defined(__AVX512VPOPCNTDQ__) && defined(__AVX512VL__)
+                __m128i popcnt = _mm_popcnt_epi64(vxor);
+                count += _mm_extract_epi64(popcnt, 0);
+                count += _mm_extract_epi64(popcnt, 1);
+#else
+                count += _mm_popcnt_u64(_mm_extract_epi64(vxor, 0));
+                count += _mm_popcnt_u64(_mm_extract_epi64(vxor, 1));
+#endif
+                a += 16;
+                b += 16;
+          }
+          return static_cast<double>(count);
     }
-    return static_cast<double>(count);
-}
 
 #endif
 


### PR DESCRIPTION
Bugfix of https://github.com/yahoojapan/NGT/issues/161

I've fixed the problem that _mm512_extract_epi64 is not a supported instruction.
So use _mm512_extracti64x4_epi64 to split into upper and lower bits and use 256 for calculation.
If AVX512VPOPCNTDQ is supported, use _mm512_popcnt_epi64 without extract.