### PR TITLE
Export NGT Property to C API and add struct and function to get it

### DIFF
--- a/lib/NGT/Capi.cpp
+++ b/lib/NGT/Capi.cpp
@@ -395,6 +395,70 @@ bool ngt_set_property_distance_type_inner_product(NGTProperty prop, NGTError err
   return ngt_set_property_distance_type(prop, NGT::Index::Property::DistanceType::DistanceTypeInnerProduct, error);
 }
 
+NGTPropertyInfo ngt_get_property_info(NGTIndex index, NGTError error) {
+  NGT::Property prop;
+  try {
+    static_cast<NGT::Index*>(index)->getProperty(prop);
+  } catch(std::exception &err) {
+    std::stringstream ss;
+    ss << "Capi : " << __FUNCTION__ << "() : Error: " << err.what();
+    operate_error_string_(ss, error);
+    NGTPropertyInfo err_val = {0};
+    return err_val;
+  }
+  NGTPropertyInfo info = {
+    prop.dimension,
+    prop.threadPoolSize,
+    prop.objectType,
+    prop.distanceType,
+    prop.indexType,
+    prop.databaseType,
+    prop.objectAlignment,
+    prop.pathAdjustmentInterval,
+#ifdef NGT_SHARED_MEMORY_ALLOCATOR
+    prop.graphSharedMemorySize,
+    prop.treeSharedMemorySize,
+    prop.objectSharedMemorySize,
+#else
+    -1,
+    -1,
+    -1,
+#endif
+    prop.prefetchOffset,
+    prop.prefetchSize,
+    prop.accuracyTable.c_str(),
+    prop.searchType.c_str(),
+#ifdef NGT_INNER_PRODUCT
+    prop.maxMagnitude,
+#else
+    -1,
+#endif
+    prop.nOfNeighborsForInsertionOrder,
+    prop.epsilonForInsertionOrder,
+#ifdef NGT_REFINEMENT
+    prop.refinementObjectType,
+#else
+    -1,
+#endif
+    prop.truncationThreshold,
+    prop.edgeSizeForCreation,
+    prop.edgeSizeForSearch,
+    prop.edgeSizeLimitForCreation,
+    prop.insertionRadiusCoefficient,
+    prop.seedSize,
+    prop.seedType,
+    prop.truncationThreadPoolSize,
+    prop.batchSizeForCreation,
+    prop.graphType,
+    prop.dynamicEdgeSizeBase,
+    prop.dynamicEdgeSizeRate,
+    prop.buildTimeLimit,
+    prop.outgoingEdge,
+    prop.incomingEdge
+  };
+  return info;
+}
+
 NGTObjectDistances ngt_create_empty_results(NGTError error) {
   try{
     return static_cast<NGTObjectDistances>(new NGT::ObjectDistances());

--- a/lib/NGT/Capi.h
+++ b/lib/NGT/Capi.h
@@ -119,6 +119,43 @@ typedef struct {
   size_t indegreeHistogramSize;
 } NGTGraphStatistics;
 
+typedef struct {
+  int dimension;
+  int thread_pool_size;
+  int object_type;
+  int distance_type;
+  int index_type;
+  int database_type;
+  int object_alignment;
+  int path_adjustment_interval;
+  int graph_shared_memory_size;
+  int tree_shared_memory_size;
+  int object_shared_memory_size;
+  int prefetch_offset;
+  int prefetch_size;
+  const char* accuracy_table;
+  const char* search_type;
+  float max_magnitude;
+  int n_of_neighbors_for_insertion_order;
+  float epsilon_for_insertion_order;
+  int refinement_object_type;
+  int16_t truncation_threshold;
+  int16_t edge_size_for_creation;
+  int16_t edge_size_for_search;
+  int16_t edge_size_limit_for_creation;
+  double insertion_radius_coefficient;
+  int16_t seed_size;
+  int seed_type;
+  int16_t truncation_thread_pool_size;
+  int16_t batch_size_for_creation;
+  int graph_type;
+  int16_t dynamic_edge_size_base;
+  int16_t dynamic_edge_size_rate;
+  float build_time_limit;
+  int16_t outgoing_edge;
+  int16_t incoming_edge;
+} NGTPropertyInfo;
+
 NGTIndex ngt_open_index(const char *, NGTError);
 
 NGTIndex ngt_open_index_as_read_only(const char *, NGTError);
@@ -184,6 +221,8 @@ bool ngt_set_property_distance_type_normalized_angle(NGTProperty, NGTError);
 bool ngt_set_property_distance_type_normalized_cosine(NGTProperty, NGTError);
 
 bool ngt_set_property_distance_type_inner_product(NGTProperty, NGTError);
+
+NGTPropertyInfo ngt_get_property_info(NGTIndex, NGTError);
 
 NGTObjectDistances ngt_create_empty_results(NGTError);
 


### PR DESCRIPTION
Add new struct and function for exporting `NGT::Property` to C API.

And I run check program written in C.
I have confirmed blow:
- insertionRadiusCoefficient(insertion_radius_coefficient in C API) is referred to as EpsilonForCreation in the prf file.
- searchType (search_type in C API) does not output to prf.
```
$ cat main.c
#include <NGT/Capi.h>
#include <stdio.h>

void output(NGTPropertyInfo info) {
    printf("accuracy_table\t%s\n", info.accuracy_table);
    printf("batch_size_for_creation\t%d\n", info.batch_size_for_creation);
    printf("build_time_limit\t%f\n", info.build_time_limit);
    printf("database_type\t%d\n", info.database_type);
    printf("dimension\t%d\n", info.dimension);
    printf("distance_type\t%d\n", info.distance_type);
    printf("dynamic_edge_size_base\t%d\n", info.dynamic_edge_size_base);
    printf("dynamic_edge_size_rate\t%d\n", info.dynamic_edge_size_rate);
    printf("edge_size_for_creation\t%d\n", info.edge_size_for_creation);
    printf("edge_size_for_search\t%d\n", info.edge_size_for_search);
    printf("edge_size_limit_for_creation\t%d\n", info.edge_size_limit_for_creation);
    printf("epsilon_for_insertion_order\t%f\n", info.epsilon_for_insertion_order);
    printf("insertion_radius_coefficient(epsilon_for_creation)\t%f\n", info.insertion_radius_coefficient);
    printf("graph_type\t%d\n", info.graph_type);
    printf("incoming_edge\t%d\n", info.incoming_edge);
    printf("truncation_threshold(incremental_edge_size_limit_for_truncation)\t%d\n", info.truncation_threshold);
    printf("index_type\t%d\n", info.index_type);
    printf("max_magnitude\t%f\n", info.max_magnitude);
    printf("n_of_neighbors_for_insertion_order\t%d\n", info.n_of_neighbors_for_insertion_order);
    printf("object_alignment\t%d\n", info.object_alignment);
    printf("object_type\t%d\n", info.object_type);
    printf("outgoing_edge\t%d\n", info.outgoing_edge);
    printf("path_adjustment_interval\t%d\n", info.path_adjustment_interval);
    printf("prefetch_size\t%d\n", info.prefetch_size);
    printf("prefetch_offset\t%d\n", info.prefetch_offset);
    printf("seed_size\t%d\n", info.seed_size);
    printf("seed_type\t%d\n", info.seed_type);
    printf("thread_pool_size\t%d\n", info.thread_pool_size);
    printf("truncation_thread_pool_size\t%d\n", info.truncation_thread_pool_size);
    printf("\n");
    printf("graph_shared_memory_size\t%d\n", info.graph_shared_memory_size);
    printf("tree_shared_memory_size\t%d\n", info.tree_shared_memory_size);
    printf("object_shared_memory_size\t%d\n", info.object_shared_memory_size);
    printf("search_type\t%s\n", info.search_type);
    printf("refinement_object_type\t%d\n", info.refinement_object_type);
}

int main() {
    NGTError error = ngt_create_error_object();
    NGTProperty prop = ngt_create_property(error);
    ngt_set_property_dimension(prop, 128, error);
    ngt_set_property_distance_type_l2(prop, error);
    NGTIndex index = ngt_create_graph_and_tree("./index", prop, error);
    ngt_destroy_property(prop);

    NGTPropertyInfo info = ngt_get_property_info(index, error);
    output(info);

    ngt_save_index(index, "./index", error);
}
```

```
$ ./a.out
accuracy_table
batch_size_for_creation 200
build_time_limit        0.000000
database_type   1
dimension       128
distance_type   1
dynamic_edge_size_base  30
dynamic_edge_size_rate  20
edge_size_for_creation  10
edge_size_for_search    0
edge_size_limit_for_creation    5
epsilon_for_insertion_order     0.100000
insertion_radius_coefficient(epsilon_for_creation)      1.100000
graph_type      1
incoming_edge   80
truncation_threshold(incremental_edge_size_limit_for_truncation)        0
index_type      1
max_magnitude   0.000000
n_of_neighbors_for_insertion_order      0
object_alignment        2
object_type     2
outgoing_edge   10
path_adjustment_interval        0
prefetch_size   512
prefetch_offset 2
seed_size       10
seed_type       0
thread_pool_size        32
truncation_thread_pool_size     8

graph_shared_memory_size        -1
tree_shared_memory_size -1
object_shared_memory_size       -1
search_type
refinement_object_type  -1
$ cat ./index/prf
AccuracyTable
BatchSizeForCreation    200
BuildTimeLimit  0
DatabaseType    Memory
Dimension       128
DistanceType    L2
DynamicEdgeSizeBase     30
DynamicEdgeSizeRate     20
EdgeSizeForCreation     10
EdgeSizeForSearch       0
EdgeSizeLimitForCreation        5
EpsilonForCreation      0.1
EpsilonForInsertionOrder        0.1
GraphType       ANNG
IncomingEdge    80
IncrimentalEdgeSizeLimitForTruncation   0
IndexType       GraphAndTree
MaxMagnitude    0
NumberOfNeighborsForInsertionOrder      0
ObjectAlignment False
ObjectType      Float-4
OutgoingEdge    10
PathAdjustmentInterval  0
PrefetchOffset  2
PrefetchSize    512
SeedSize        10
SeedType        None
ThreadPoolSize  32
TruncationThreadPoolSize        8
```