### PR TITLE
fix narrowing conversion error

### DIFF
--- a/lib/NGT/Capi.cpp
+++ b/lib/NGT/Capi.cpp
@@ -484,7 +484,7 @@ NGTPropertyInfo ngt_get_property_info(NGTIndex index, NGTError error) {
                           prop.buildTimeLimit,
                           prop.outgoingEdge,
                           prop.incomingEdge,
-                          prop.insertionRadiusCoefficient - 1.0};
+                          static_cast<float>(prop.insertionRadiusCoefficient - 1.0)};
   return info;
 }
 


### PR DESCRIPTION
seeing some narrowing conversion error for macos builds

```
  /tmp/ngt-20250120-5131-bvlk6j/NGT-2.3.8/lib/NGT/Capi.cpp:487:27: error: non-constant-expression cannot be narrowed from type 'double' to 'float' in initializer list [-Wc++11-narrowing]
    487 |                           prop.insertionRadiusCoefficient - 1.0};
        |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /tmp/ngt-20250120-5131-bvlk6j/NGT-2.3.8/lib/NGT/Capi.cpp:487:27: note: insert an explicit cast to silence this issue
    487 |                           prop.insertionRadiusCoefficient - 1.0};
        |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        |                           static_cast<float>(                  )
  1 error generated.
```

- https://github.com/Homebrew/homebrew-core/pull/204986