### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(APPLE)
     cmake_minimum_required(VERSION 3.0)
 else()
-    cmake_minimum_required(VERSION 2.8)
+    cmake_minimum_required(VERSION 3.5..3.31)
 endif()
 
 project(ngt)


### PR DESCRIPTION
Description of changes:

[CMake 4.0](https://cmake.org/cmake/help/latest/release/4.0.html) is out and requires cmake_minimum_required to be at least 3.5:

    Compatibility with versions of CMake older than 3.5 has been removed. Calls to [cmake_minimum_required()](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required) or [cmake_policy()](https://cmake.org/cmake/help/latest/command/cmake_policy.html#command:cmake_policy) that set the policy version to an older value now issue an error

This will break any customer using CMake version less than 3.9 which was [released in November 2018](https://github.com/Kitware/CMake/releases/tag/v3.9.0)
