### PR TITLE
fix: comparator build on x86_64 and arm64

### DIFF
--- a/lib/NGT/PrimitiveComparatorArm.h
+++ b/lib/NGT/PrimitiveComparatorArm.h
@@ -463,7 +463,7 @@ class PrimitiveComparator {
     float sum = vaddvq_f32(sum_vec);
 
     while (a < last) {
-      float diff = static_cast<float>(*a++) - static_cast<float>(*b++);
+      float diff = vcvtah_f32_bf16(*a++) - vcvtah_f32_bf16(*b++);
       sum += diff * diff;
     }
 

--- a/lib/NGT/PrimitiveComparatorX86.h
+++ b/lib/NGT/PrimitiveComparatorX86.h
@@ -848,6 +848,7 @@ class PrimitiveComparator {
   }
   inline static double compareDotProduct(const int8_t *a, const int8_t *b, size_t size) {
     const auto *last = a + size;
+    __m128i sum128   = _mm_setzero_si128();
 #if defined(NGT_AVX512) || defined(NGT_AVX2)
 #if defined(NGT_AVX512)
     __m512i sum512 = _mm512_setzero_si512();
@@ -886,7 +887,7 @@ class PrimitiveComparator {
         b += 32;
       }
     }
-    __m128i sum128 = _mm_add_epi32(_mm256_extracti128_si256(sum256, 0), _mm256_extracti128_si256(sum256, 1));
+    sum128 = _mm_add_epi32(_mm256_extracti128_si256(sum256, 0), _mm256_extracti128_si256(sum256, 1));
 #endif
     {
       const auto *lastgroup = last - 15;


### PR DESCRIPTION
This fixes two compile regressions affecting Linux CI builds:

- Initialize `sum128` in `PrimitiveComparatorX86.h` so the non-AVX2/AVX512 path compiles.
- Use `vcvtah_f32_bf16` for scalar `bfloat16_t` conversion in `PrimitiveComparatorArm.h` to avoid arm64 GCC build failures.

These are minimal changes intended to preserve current behavior while restoring cross-architecture builds.
