### PR TITLE
Fix generic x86 and disabled-bfloat ARM builds

### DIFF
--- a/lib/NGT/PrimitiveComparator.h
+++ b/lib/NGT/PrimitiveComparator.h
@@ -20,7 +20,7 @@
 
 #if defined(NGT_NO_SIMD)
 #include "NGT/PrimitiveComparatorNoArch.h"
-#elif defined(__x86_64__)
+#elif defined(__x86_64__) && !defined(NGT_NO_AVX)
 #include "NGT/PrimitiveComparatorX86.h"
 #elif defined(NGT_NEON)
 #include "NGT/PrimitiveComparatorArm.h"

--- a/lib/NGT/PrimitiveComparatorArm.h
+++ b/lib/NGT/PrimitiveComparatorArm.h
@@ -445,6 +445,7 @@ class PrimitiveComparator {
   }
 #endif
 
+#ifdef NGT_BFLOAT
   inline static double compareL2(const bfloat16_t *a, const bfloat16_t *b, size_t size) {
     float32x4_t sum_vec = vdupq_n_f32(0.0f);
 
@@ -469,6 +470,7 @@ class PrimitiveComparator {
 
     return std::sqrt(sum);
   }
+#endif
 
   inline static double compareL2(const half_float::half *a, const half_float::half *b, size_t size) {
     double sum = 0.0;

--- a/lib/NGT/PrimitiveComparatorNoArch.cpp
+++ b/lib/NGT/PrimitiveComparatorNoArch.cpp
@@ -16,7 +16,9 @@
 
 #include "NGT/defines.h"
 
-#if defined(NGT_NO_SIMD) && defined(NGT_PQ4)
+#if defined(NGT_PQ4) &&                                                               \
+    (defined(NGT_NO_SIMD) || (defined(__x86_64__) && defined(NGT_NO_AVX)) ||          \
+     (!defined(__x86_64__) && !defined(NGT_NEON)))
 
 #include "NGT/Common.h"
 #include "NGT/PrimitiveComparator.h"


### PR DESCRIPTION
Fixes two build failures seen when packaging NGT 2.7.4 with generic CPU flags:

- x86_64 builds with `NGT_MARCH_NATIVE_DISABLED=ON` define `NGT_NO_AVX`, but still included `PrimitiveComparatorX86.h`; that header assumes non-baseline x86 intrinsics are available. Use the generic comparator when AVX is unavailable.
- ARM builds with `NGT_BFLOAT_DISABLED=ON` still compiled the native `bfloat16_t` L2 overload. Guard it with `NGT_BFLOAT` so disabled-bfloat builds do not compile bfloat code.

This keeps NEON enabled on ARM and keeps the x86 SIMD comparator for AVX-capable builds.

References Homebrew/homebrew-core#278575.
